### PR TITLE
Use mktmpdir instead of creating temp_email directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,8 @@ It doesn't matter what directory you're in when you run this command.
 That's basically all there is to it!
 
 ###Known Issues
-* *"temp_email" already exists*
 * *no email addresses are returned*
 * *email address is unused*
-
-If you already have a folder named "temp_email", this program will not work correctly. It tries to clone the repo you input into a folder it creates called temp_folder. If temp_folder already exists, the program by default will not force the repo into the already existing folder. I suggest renaming your temp_email folder, or, if you have some ruby knowledge, editing the finder.rb file to create a temporary folder called something else.
 
 If no email addresses are returned, this means that the github user set his email to private. Most emails are not private however - even when an email does not appear on a person's github profile, it still usually is public in their git logs.
 

--- a/gitmail.rb
+++ b/gitmail.rb
@@ -1,10 +1,13 @@
+require 'tmpdir'
+
 class Finder
   def initialize(repo_name)
-    `git clone https://github.com/#{repo_name}.git temp_email`
-    Dir.chdir("temp_email")
-    @emails = `git log --pretty=format:'%an %ae'`
-    Dir.chdir("..")
-    `rm -rf temp_email`
+    Dir.mktmpdir("GitMail") do |dir|
+      `git clone https://github.com/#{repo_name}.git #{dir}`
+      Dir.chdir("#{dir}") do
+        @emails = `git log --pretty=format:'%an %ae'`
+      end
+    end
   end
 
   def all_contributors

--- a/gitmail.rb
+++ b/gitmail.rb
@@ -3,7 +3,7 @@ require 'tmpdir'
 class Finder
   def initialize(repo_name)
     Dir.mktmpdir("GitMail") do |dir|
-      `git clone https://github.com/#{repo_name}.git #{dir}`
+      `git clone --bare https://github.com/#{repo_name}.git #{dir}`
       Dir.chdir("#{dir}") do
         @emails = `git log --pretty=format:'%an %ae'`
       end


### PR DESCRIPTION
The Dir.mktmpdir method automatically creates a temporary folder and cleans it up at the end of the block.

Much cleaner than manually creating and deleting the folder
